### PR TITLE
Fixed rss_limit from default to fixed 4096mb, large enough to be run …

### DIFF
--- a/cifuzz.yaml
+++ b/cifuzz.yaml
@@ -22,8 +22,8 @@
 
 ## Command-line arguments to pass to libFuzzer.
 ## See https://llvm.org/docs/LibFuzzer.html#options
-#engine-args:
-# - -rss_limit_mb=4096
+engine-args:
+ - -rss_limit_mb=4096
 
 ## Maximum time to run fuzz tests. The default is to run indefinitely.
 #timeout: 30m


### PR DESCRIPTION
…on the CI APP