### PR TITLE
fix: prefix rss_limit_mb engine-args with -Djazzer.

### DIFF
--- a/cifuzz.yaml
+++ b/cifuzz.yaml
@@ -23,7 +23,7 @@
 ## Command-line arguments to pass to libFuzzer.
 ## See https://llvm.org/docs/LibFuzzer.html#options
 engine-args:
- - -rss_limit_mb=4096
+ - -Djazzer.rss_limit_mb=4096
 
 ## Maximum time to run fuzz tests. The default is to run indefinitely.
 #timeout: 30m


### PR DESCRIPTION
Fixes the usage of the `rss_limit_mb` engine arg.

[CLI-1025](https://code-intelligence.atlassian.net/browse/CLI-1025)